### PR TITLE
feat: add unit tests for facts service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "eslint-plugin-jest": "^28.11.0",
         "eslint-plugin-prettier": "^5.0.0",
         "jest": "^29.7.0",
+        "jest-mock-extended": "^4.0.0-beta1",
         "nodemon": "^3.1.7",
         "prettier": "^3.3.3",
         "prisma": "^6.2.1",
@@ -9574,6 +9575,21 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-mock-extended": {
+      "version": "4.0.0-beta1",
+      "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-4.0.0-beta1.tgz",
+      "integrity": "sha512-MYcI0wQu3ceNhqKoqAJOdEfsVMamAFqDTjoLN5Y45PAG3iIm4WGnhOu0wpMjlWCexVPO71PMoNir9QrGXrnIlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-essentials": "^10.0.2"
+      },
+      "peerDependencies": {
+        "@jest/globals": "^28.0.0 || ^29.0.0",
+        "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
+        "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -13158,6 +13174,21 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-essentials": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.0.4.tgz",
+      "integrity": "sha512-lwYdz28+S4nicm+jFi6V58LaAIpxzhg9rLdgNC1VsdP/xiFBseGhF1M/shwCk6zMmwahBZdXcl34LVHrEang3A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ts-jest": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.7.0",
+    "jest-mock-extended": "^4.0.0-beta1",
     "nodemon": "^3.1.7",
     "prettier": "^3.3.3",
     "prisma": "^6.2.1",

--- a/src/__mocks__/dbClient.ts
+++ b/src/__mocks__/dbClient.ts
@@ -1,0 +1,4 @@
+import { PrismaClient } from "@prisma/client";
+import { mockDeep } from "jest-mock-extended";
+
+export const mockPrisma = mockDeep<PrismaClient>();

--- a/src/server/plugins/services/FactService.ts
+++ b/src/server/plugins/services/FactService.ts
@@ -10,30 +10,17 @@ type GetFactsOptions = {
 
 export class FactService {
   client: PrismaClient;
-  private _totalFacts: number;
 
   constructor(server: FastifyInstance) {
     this.client = server["dbClient"];
-    this._totalFacts = 0;
   }
 
-  async initTotalFacts() {
-    this._totalFacts = await this.client.fact.count();
-  }
-
-  public get totalFacts() {
-    return this._totalFacts;
-  }
-
-  public set totalFacts(total: number) {
-    this._totalFacts = total;
+  async getTotalFacts() {
+    return this.client.fact.count();
   }
 
   async getRandomFact() {
-    const totalFacts = this._totalFacts;
-    if (totalFacts === 0) {
-      await this.initTotalFacts();
-    }
+    const totalFacts = await this.getTotalFacts();
     const index = randomInt(totalFacts);
     return this.client.fact.findMany({
       skip: index,
@@ -62,14 +49,9 @@ export class FactService {
   }
 
   async createFact(data: Prisma.FactCreateArgs["data"]) {
-    if (this.totalFacts === 0) {
-      await this.initTotalFacts();
-    }
-    const newFact = await this.client.fact.create({
+    return this.client.fact.create({
       data,
     });
-    this.totalFacts = this.totalFacts + 1;
-    return newFact;
   }
 
   async getFactById(id: number) {
@@ -133,12 +115,10 @@ export class FactService {
   }
 
   async deleteFact(id: number) {
-    const deletedFact = await this.client.fact.delete({
+    return this.client.fact.delete({
       where: {
         id,
       },
     });
-    this.totalFacts = this.totalFacts - 1;
-    return deletedFact;
   }
 }

--- a/src/server/plugins/services/__tests__/FactService.test.ts
+++ b/src/server/plugins/services/__tests__/FactService.test.ts
@@ -51,17 +51,6 @@ describe("factsService", () => {
     };
   });
 
-  it("Should set total facts properly when instantiating the service", async () => {
-    const factsService = new FactService(server as FastifyInstance);
-    expect(factsService.totalFacts).toBe(0);
-  });
-
-  it("Should successfully set the total facts when total facts is updated", () => {
-    const factsService = new FactService(server as FastifyInstance);
-    factsService.totalFacts = factsService.totalFacts + 1;
-    expect(factsService.totalFacts).toBe(1);
-  });
-
   it("Should successfully return a random fact when getRandomFact is called", async () => {
     // @ts-ignore
     jest.spyOn(crypto, "randomInt").mockReturnValueOnce(6);
@@ -121,7 +110,8 @@ describe("factsService", () => {
     const factsService = new FactService(server as FastifyInstance);
     const result = await factsService.createFact(newFact);
     expect(result).toEqual(newFact);
-    expect(factsService.totalFacts).toBe(11);
+    const totalFacts = await factsService.getTotalFacts();
+    expect(totalFacts).toBe(11);
   });
 
   it("Should return a fact with a specific id when getFactById is called", async () => {

--- a/src/server/plugins/services/__tests__/FactService.test.ts
+++ b/src/server/plugins/services/__tests__/FactService.test.ts
@@ -1,0 +1,145 @@
+import { FastifyInstance } from "fastify";
+import { mockPrisma } from "../../../../__mocks__/dbClient";
+import { mockReset } from "jest-mock-extended";
+import { FactService } from "../FactService";
+import { Category, Fact } from "@prisma/client";
+import { nanoid } from "nanoid";
+import crypto from "node:crypto";
+
+function createRandomFacts(quantity: number, randomCategory?: boolean) {
+  const returnArray: Fact[] = [];
+  const categories: Category[] = ["FILM", "HISTORY", "SCIENCE", "MUSIC"];
+  for (let i = 0; i < quantity; i++) {
+    let selectedCategory: Category | undefined = undefined;
+    if (randomCategory) {
+      selectedCategory = categories[crypto.randomInt(4)];
+    }
+    returnArray.push({
+      id: i,
+      friendlyName: nanoid(16),
+      category: selectedCategory ?? "FILM",
+      content: nanoid(32),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+  return returnArray;
+}
+
+function createFactsWithName(quantity: number, friendlyName: string, startAt: number) {
+  const returnArray: Fact[] = [];
+  for (let i = startAt; i < startAt + quantity; i++) {
+    returnArray.push({
+      id: i,
+      friendlyName: friendlyName,
+      category: "FILM",
+      content: nanoid(32),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+  return returnArray;
+}
+
+describe("factsService", () => {
+  let server: Partial<FastifyInstance>;
+  beforeEach(() => {
+    mockReset(mockPrisma);
+    server = {
+      // @ts-ignore
+      dbClient: mockPrisma,
+    };
+  });
+
+  it("Should set total facts properly when instantiating the service", async () => {
+    const factsService = new FactService(server as FastifyInstance);
+    expect(factsService.totalFacts).toBe(0);
+  });
+
+  it("Should successfully set the total facts when total facts is updated", () => {
+    const factsService = new FactService(server as FastifyInstance);
+    factsService.totalFacts = factsService.totalFacts + 1;
+    expect(factsService.totalFacts).toBe(1);
+  });
+
+  it("Should successfully return a random fact when getRandomFact is called", async () => {
+    // @ts-ignore
+    jest.spyOn(crypto, "randomInt").mockReturnValueOnce(6);
+    const totalFacts = 10;
+    const allFacts = createRandomFacts(totalFacts);
+
+    server["dbClient"].fact.findMany.mockResolvedValueOnce(allFacts[6]);
+
+    const factsService = new FactService(server as FastifyInstance);
+    const result = await factsService.getRandomFact();
+    expect(result).toEqual(allFacts[6]);
+  });
+
+  it("Should successfully return a random fact from a specific category when getCategoryFact is called", async () => {
+    const allFacts = createRandomFacts(10, true);
+    const category = "FILM";
+    const categoryFacts = allFacts.filter((fact) => fact.category === category);
+    const numberOfCategoryFacts = categoryFacts.length;
+    const indexToTake = Math.floor(Math.random() * (numberOfCategoryFacts - 1));
+
+    //@ts-ignore
+    jest.spyOn(crypto, "randomInt").mockReturnValueOnce(indexToTake);
+    server["dbClient"].fact.count.mockImplementationOnce((_options: Record<string, any>) => {
+      return numberOfCategoryFacts;
+    });
+    server["dbClient"].fact.findMany.mockImplementationOnce((options: Record<string, any>) => {
+      return categoryFacts[options.skip];
+    });
+
+    const factsService = new FactService(server as FastifyInstance);
+    const result = await factsService.getCategoryFact(category);
+    expect(result).toEqual(categoryFacts[indexToTake]);
+  });
+
+  it("Should get the correct number of facts in a category when getTotalFactsForCategory is called", async () => {
+    const allFacts = createRandomFacts(10, true);
+    const category = "FILM";
+    const numberOfFactsForCategory = allFacts.filter((fact) => fact.category === category).length;
+
+    server["dbClient"].fact.count.mockImplementationOnce((options: Record<string, any>) => {
+      return allFacts.filter((fact) => fact.category === options.where.category).length;
+    });
+
+    const factsService = new FactService(server as FastifyInstance);
+    const result = await factsService.getTotalFactsForCategory(category);
+    expect(result).toBe(numberOfFactsForCategory);
+  });
+
+  it("Should return a new fact and update total facts when createFact is called", async () => {
+    const newFact = createRandomFacts(1)[0];
+
+    server["dbClient"].fact.count.mockResolvedValueOnce(10);
+    server["dbClient"].fact.create.mockImplementationOnce(({ data }) => {
+      return data;
+    });
+
+    const factsService = new FactService(server as FastifyInstance);
+    const result = await factsService.createFact(newFact);
+    expect(result).toEqual(newFact);
+    expect(factsService.totalFacts).toBe(11);
+  });
+
+  it("Should return a fact with a specific id when getFactById is called", () => {
+    const allFacts = createRandomFacts(10);
+    server["dbClient"].fact.find();
+  });
+  // describe("getFacts", () => {
+  //   beforeEach(() => {
+  //     const allFacts = createRandomFacts(10).concat(createFactsWithName(10, "A common name", 10));
+  //     server["dbClient"].facts.findMany.mockImplementationOnce((options) => {
+  //       if(options.orderBy){
+  //
+  //       }
+  //     });
+  //   });
+  //   it("Should return the first 10 facts when getFacts is called with no filters", () => {});
+  //   it("Should return the second 10 facts when getFacts is called with page passed", () => {});
+  //   it("Should return the first 10 facts sorted by name if getFacts is called with the sort order 'name'", () => {});
+  //   it("Should return the first 10 facts that match the search string when getFacts is called with a search string", () => {});
+  // });
+});

--- a/src/server/plugins/services/__tests__/FactService.test.ts
+++ b/src/server/plugins/services/__tests__/FactService.test.ts
@@ -102,7 +102,7 @@ describe("factsService", () => {
   it("Should return a new fact and update total facts when createFact is called", async () => {
     const newFact = createRandomFacts(1)[0];
 
-    server["dbClient"].fact.count.mockResolvedValueOnce(10);
+    server["dbClient"].fact.count.mockResolvedValueOnce(11);
     server["dbClient"].fact.create.mockImplementationOnce(({ data }) => {
       return data;
     });

--- a/src/server/routes/admin/facts/new/post.ts
+++ b/src/server/routes/admin/facts/new/post.ts
@@ -10,7 +10,6 @@ async function post(req: FactPostReq, reply: FastifyReply) {
       createdAt: new Date(),
       updatedAt: new Date(),
     });
-    factService.totalFacts = factService.totalFacts + 1;
     req.log.info(`Fact updated: ${createdFact}`);
     req.flash("success", ["Fact created"]);
     reply.redirect(`/admin/facts/${createdFact.id}`);


### PR DESCRIPTION
## Changes

- Add `json-mock-extended` for mocking prisma
- Add top level mock for prisma for unit tests
- Remove total facts functionality to couple total facts more closely with actual real time results
- Adds unit tests for facts service